### PR TITLE
feat: 도메인 엔티티 클래스 작성 (게시글 - 아이템)

### DIFF
--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Achievement.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Achievement.java
@@ -1,0 +1,27 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "achievements")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Achievement {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column (name = "goal")
+    private String goal;
+
+    @Column(name = "reward")
+    private Integer reward;
+
+    @Column(name="img_url")
+    private String imgUrl;
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Article.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Article.java
@@ -1,0 +1,64 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity(name = "articles")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Article {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // auto-increment
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content")
+    private String content;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "modified_at")
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "like_count")
+    private Integer likeCount;
+
+    @Column(name = "view_count")
+    private Integer viewCount;
+
+    @Column(name = "comment_count")
+    private Integer commentCount;
+
+    @Column(name = "board_type")
+    private Integer boardType;
+
+    @Column(name = "notice")
+    private Boolean notice;
+
+    @Column(name = "start")
+    private Integer start;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "vcourse_id")
+    private Long vcourseId;
+
+    @Column(name = "disease_id")
+    private Integer diseaseId;
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/ArticleImage.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/ArticleImage.java
@@ -1,0 +1,24 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "article_images")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ArticleImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "img_url")
+    private String imgUrl;
+
+    @Column(name = "article_id")
+    private Long articleId;
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Attraction.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Attraction.java
@@ -1,0 +1,61 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "attractions")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Attraction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "content_id")
+    private Integer contentId;
+
+    private String title;
+
+    @Column(name = "first_image")
+    private String firstImage;
+
+    @Column(name = "first_image2")
+    private String firstImage2;
+
+    @Column(name = "map_level")
+    private Integer mapLevel;
+
+    @Column(name = "latitude")
+    private Double latitude;
+
+    @Column(name = "longitude")
+    private Double longitude;
+
+    @Column(name = "tel")
+    private String tel;
+
+    @Column(name = "addr1")
+    private String addr1;
+
+    @Column(name = "addr2")
+    private String addr2;
+
+    @Column(name = "homepage")
+    private String homepage;
+
+    @Column(name = "overview")
+    private String overview;
+
+    @Column(name = "content_type_id")
+    private Integer contentTypeId;
+
+    @Column(name = "sido_code")
+    private Integer sidoCode;
+
+    @Column(name = "sigungu_code")
+    private Integer sigunguCode;
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/ContentType.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/ContentType.java
@@ -1,0 +1,21 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "contenttypes")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ContentType {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Course.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Course.java
@@ -9,51 +9,55 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@Entity
+@Entity(name = "courses")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 public class Course implements JsonSettable {
-    public final String PN_ROUTE_IDX = "routeIdx";
-    public final String PN_CRS_IDX = "crsIdx";
-    public final String PN_CRS_KOR_NM = "crsKorNm";
-    public final String PN_CRS_DSTNC = "crsDstnc";
-    public final String PN_CRS_TOTL_RQRMHOUR = "crsTotlReqHour";
-    public final String PN_CRS_LEVEL = "crsLevel";
-    public final String PN_CRS_CYCLE = "crsCycle";
-    public final String PN_CRS_CONTENTS = "crsContents";
-    public final String PN_CRS_SUMMARY = "crsSummary";
-    public final String PN_CRS_TOUR_INFO = "crsTourInfo";
-    public final String PN_TRAVELER_INFO = "travelerinfo";
-    public final String PN_SIGUN = "sigun";
-    public final String PN_BRD_DIV = "brdDiv";
-    public final String PN_CREATED_TIME = "createdtime";
-    public final String PN_MODIFIED_TIME = "modifiedtime";
-
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY) // auto-increment
     @Column(name = "id")
     private Long id;
 
+    @Column(name = "theme_id")
+    private Long themeId;
+
     @Column(name = "idx")
     private String idx;
 
-    @Column(name = "distance")
-    private Double distance;
+    @Column(name = "route_idx")
+    private String routeIdx;
 
     @Column(name = "name")
     private String name;
 
+    @Column(name = "distance")
+    private Double distance;
+
+    @Column(name = "req_time")
+    private Double reqTime;
+
     @Column(name = "level")
     private Integer level;
 
-    @Column(name = "line_msg")
-    private String lineMsg;
+    @Column(name = "cycle")
+    private Boolean cycle;
 
-    @Column(name = "overview")
-    private String overview;
+    @Column(name = "summary")
+    private String summary;
+
+    @Column(name = "contents")
+    private String contents;
+
+    @Column(name = "traveler_info")
+    private String travelerInfo;
+
+    @Column(name = "sido_code")
+    private Integer sidoCode;
+
+    @Column(name = "sigungu_code")
+    private Integer sigunguCode;
 
     @Column(name = "brd_div")
     private Boolean brdDiv;
@@ -64,14 +68,9 @@ public class Course implements JsonSettable {
     @Column(name = "modified_at")
     private LocalDateTime modifiedAt;
 
-    @Column(name = "route_idx")
-    private String routeIdx;
+    @Column(name = "reward")
+    private Integer reward;
 
-    @Column(name = "sido_code")
-    private Integer sidoCode;
-
-    @Column(name = "sigungu_code")
-    private Integer sigunguCode;
 
 
     @Override
@@ -81,12 +80,33 @@ public class Course implements JsonSettable {
         this.distance = object.get(PN_CRS_DSTNC).getAsDouble();
         this.name = object.get(PN_CRS_KOR_NM).getAsString();
         this.level = object.get(PN_CRS_LEVEL).getAsInt();
-        this.lineMsg = object.get(PN_CRS_SUMMARY).getAsString();
-        this.overview = object.get(PN_CRS_CONTENTS).getAsString();
+        this.summary = object.get(PN_CRS_SUMMARY).getAsString();
+        this.contents = object.get(PN_CRS_CONTENTS).getAsString();
+        this.reqTime = object.get(PN_CRS_TOTL_RQRMHOUR).getAsDouble();
+        this.travelerInfo = object.get(PN_TRAVELER_INFO).getAsString();
+        this.cycle = object.get(PN_CRS_CYCLE).getAsString().equals("순환형");
 
         // 자전거 길 : DNBW
         this.brdDiv = object.get(PN_BRD_DIV).getAsString().equals("DNBW");
         this.createdAt = convertDateType(object.get(PN_CREATED_TIME).getAsString());
         this.modifiedAt = convertDateType(object.get(PN_MODIFIED_TIME).getAsString());
+
+        this.reward = this.level * 300;
     }
+
+    public static final String PN_ROUTE_IDX = "routeIdx";
+    public static final String PN_CRS_IDX = "crsIdx";
+    public static final String PN_CRS_KOR_NM = "crsKorNm";
+    public static final String PN_CRS_DSTNC = "crsDstnc";
+    public static final String PN_CRS_TOTL_RQRMHOUR = "crsTotlRqrmHour";
+    public static final String PN_CRS_LEVEL = "crsLevel";
+    public static final String PN_CRS_CYCLE = "crsCycle";
+    public static final String PN_CRS_CONTENTS = "crsContents";
+    public static final String PN_CRS_SUMMARY = "crsSummary";
+    public static final String PN_CRS_TOUR_INFO = "crsTourInfo";
+    public static final String PN_TRAVELER_INFO = "travelerinfo";
+    public static final String PN_SIGUN = "sigun";
+    public static final String PN_BRD_DIV = "brdDiv";
+    public static final String PN_CREATED_TIME = "createdtime";
+    public static final String PN_MODIFIED_TIME = "modifiedtime";
 }

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Disease.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Disease.java
@@ -1,0 +1,21 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "diseases")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Disease {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Inventory.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Inventory.java
@@ -1,0 +1,28 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity (name = "inventory")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Inventory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "count")
+    private int count;
+
+    @Column(name = "item_id")
+    private Long itemId;
+
+    @Column(name = "user_id")
+    private Long userId;
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Item.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Item.java
@@ -1,0 +1,39 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "items")
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Builder
+public class Item {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "price")
+    private Integer price;
+
+    @Column(name = "category")
+    private Integer category;
+
+    @Column(name = "on_sale")
+    private Boolean onSale;
+
+    @Column(name = "img_url")
+    private String imgUrl;
+
+    @Column(name = "overview")
+    private String overview;
+
+    @Column(name = "req_tier")
+    private Long reqTier;
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/PathCoord.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/PathCoord.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
-@Entity
+@Entity(name = "path_coords")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Profile.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Profile.java
@@ -1,0 +1,57 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "profiles")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Profile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "activity_point")
+    private Integer activityPoint;
+
+    @Column(name = "mileage")
+    private Integer mileage;
+
+    @Column(name = "img_url")
+    private String imgUrl;
+
+    @Column(name = "msg_frequency")
+    private String msgFrequency;
+
+    @Column(name = "msg_agree")
+    private Boolean msgAgree;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "achievement1")
+    private Long achievement1;
+
+    @Column(name = "achievement2")
+    private Long achievement2;
+
+    @Column(name = "achievement3")
+    private Long achievement3;
+
+    @Column(name = "tier_id")
+    private Long tierId;
+
+    @Column(name = "sido_code")
+    private Integer sidoCode;
+
+    @Column(name = "sigungu_code")
+    private Integer sigunguCode;
+
+    @Column(name = "diary_id")
+    private Long diaryId;
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/ProfileDeco.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/ProfileDeco.java
@@ -1,0 +1,24 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "profile_deco")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ProfileDeco {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "profile_id")
+    private Long profileId;
+
+    @Column(name = "item_id")
+    private Long itemId;
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/PurchaseHistory.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/PurchaseHistory.java
@@ -1,0 +1,35 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity(name = "purchase_history")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PurchaseHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "amount")
+    private Integer amount;
+
+    @Column(name = "bought_at")
+    private LocalDateTime boughtAt;
+
+    @Column(name = "cost")
+    private Integer cost;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "item_id")
+    private Long itemId;
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Route.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Route.java
@@ -9,20 +9,12 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@Entity
+@Entity(name = "routes")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class Gil implements JsonSettable{
-    private final String PN_ROUTE_IDX = "routeIdx";
-    private final String PN_THEME_NM = "themeNm";
-    private final String PN_LINE_MSG = "linemsg";
-    private final String PN_THEME_DESCS = "themedescs";
-    private final String PN_BRD_DIV = "brdDiv";
-    private final String PN_CREATED_TIME = "createdtime";
-    private final String PN_MODIFIED_TIME = "modifiedtime";
-
+public class Route implements JsonSettable{
     @Override
     public void setWithJson(JsonObject object) {
         this.idx = object.get(PN_ROUTE_IDX).getAsString();
@@ -61,4 +53,11 @@ public class Gil implements JsonSettable{
     @Column(name = "modified_at")
     private LocalDateTime modifiedAt;
 
+    private static final String PN_ROUTE_IDX = "routeIdx";
+    private static final String PN_THEME_NM = "themeNm";
+    private static final String PN_LINE_MSG = "linemsg";
+    private static final String PN_THEME_DESCS = "themedescs";
+    private static final String PN_BRD_DIV = "brdDiv";
+    private static final String PN_CREATED_TIME = "createdtime";
+    private static final String PN_MODIFIED_TIME = "modifiedtime";
 }

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Sido.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Sido.java
@@ -1,0 +1,22 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "sidos")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Sido {
+    @Id
+    private Integer code;
+
+    @Column(name= "name")
+    private String name;
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Sigungu.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Sigungu.java
@@ -1,0 +1,28 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "sigungus")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Sigungu {
+    @Id
+    private Integer no;
+
+    @Column(name= "name")
+    private String name;
+
+    @Column(name= "sido_code")
+    private String sidoCode;
+
+    @Column(name= "code")
+    private String code;
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Theme.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Theme.java
@@ -1,0 +1,21 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+
+import jakarta.persistence.*;
+        import lombok.AllArgsConstructor;
+        import lombok.Builder;
+        import lombok.Data;
+        import lombok.NoArgsConstructor;
+
+@Entity(name = "themes")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Theme {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "theme")
+    private String theme;
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Tier.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/domain/Tier.java
@@ -1,0 +1,27 @@
+package com.odorok.OdorokApplication.infrastructures.domain;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "tiers")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Tier {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "level")
+    private Integer level;
+
+    @Column(name = "bound")
+    private Integer bound;
+
+}

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/repository/RouteRepository.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/repository/RouteRepository.java
@@ -1,9 +1,9 @@
 package com.odorok.OdorokApplication.infrastructures.repository;
 
-import com.odorok.OdorokApplication.infrastructures.domain.Gil;
+import com.odorok.OdorokApplication.infrastructures.domain.Route;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface GilRepository extends JpaRepository<Gil, Long> {
+public interface RouteRepository extends JpaRepository<Route, Long> {
 }

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/service/DurunubiDataService.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/service/DurunubiDataService.java
@@ -1,13 +1,8 @@
 package com.odorok.OdorokApplication.infrastructures.service;
 
-import com.odorok.OdorokApplication.infrastructures.domain.Course;
-import com.odorok.OdorokApplication.infrastructures.domain.Gil;
-import com.odorok.OdorokApplication.infrastructures.dto.DurunubiCourse;
-import com.odorok.OdorokApplication.infrastructures.dto.TrackGps;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
-import java.util.List;
 
 public interface DurunubiDataService {
     // 두루누비 길 데이터 로드

--- a/src/main/java/com/odorok/OdorokApplication/infrastructures/service/DurunubiDataServiceImpl.java
+++ b/src/main/java/com/odorok/OdorokApplication/infrastructures/service/DurunubiDataServiceImpl.java
@@ -6,20 +6,24 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.odorok.OdorokApplication.commons.webflux.util.WebClientUtil;
 import com.odorok.OdorokApplication.infrastructures.domain.Course;
-import com.odorok.OdorokApplication.infrastructures.domain.Gil;
 import com.odorok.OdorokApplication.infrastructures.domain.PathCoord;
+import com.odorok.OdorokApplication.infrastructures.domain.Route;
 import com.odorok.OdorokApplication.infrastructures.repository.CourseRepository;
-import com.odorok.OdorokApplication.infrastructures.repository.GilRepository;
 import com.odorok.OdorokApplication.infrastructures.repository.PathCoordRepository;
+import com.odorok.OdorokApplication.infrastructures.repository.RouteRepository;
+import jakarta.transaction.Transactional;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
@@ -27,6 +31,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -35,12 +40,14 @@ import java.util.Map;
 @Slf4j
 public class DurunubiDataServiceImpl implements DurunubiDataService{
     private final WebClient client;
-    private final String DURUNUBI_URL_GIL_LIST = "https://apis.data.go.kr/B551011/Durunubi/routeList";
-    private final String DURUNUBI_URL_COURSE_LIST = "https://apis.data.go.kr/B551011/Durunubi/courseList";
+    private final String DURUNUBI_URL_SCHEME = "https";
+    private final String DURUNUBI_URL_HOST = "apis.data.go.kr";
+    private final String DURUNUBI_URL_GIL_PATH = "/B551011/Durunubi/routeList";
+    private final String DURUNUBI_URL_COURSE_PATH = "/B551011/Durunubi/courseList";
     private final String secretKey;
 
     private final CourseRepository courseRepository;
-    private final GilRepository gilRepository;
+    private final RouteRepository gilRepository;
     private final PathCoordRepository pathCoordRepository;
     private final Map<String, String> DURUNUBI_PARAM_MAP;
 
@@ -48,9 +55,9 @@ public class DurunubiDataServiceImpl implements DurunubiDataService{
     private final String CONTENTS_TAG_NAME = "item";
     private final String GPXPATH_PROP_NAME = "gpxpath";
 
-    public DurunubiDataServiceImpl(@Autowired @Qualifier("durudubiClient") WebClient client,
+    public DurunubiDataServiceImpl(@Autowired @Qualifier("durunubiClient") WebClient client,
                                    @Autowired CourseRepository courseRepository,
-                                   @Autowired GilRepository gilRepository,
+                                   @Autowired RouteRepository gilRepository,
                                    @Autowired PathCoordRepository pathCoordRepository,
                                    @Value("${external.keys.durunubi}") String secretKey) {
         this.client = client;
@@ -58,33 +65,38 @@ public class DurunubiDataServiceImpl implements DurunubiDataService{
         this.gilRepository = gilRepository;
         this.pathCoordRepository = pathCoordRepository;
         this.secretKey = secretKey;
-        DURUNUBI_PARAM_MAP = Map.of("MobileOs", "ETC", "MobileApp", "Odorok", "serviceKey", secretKey, "numOfRows", "8000","pageNo", "1");
+        log.debug("DURUNUBI serviceKey : {}",secretKey);
+        DURUNUBI_PARAM_MAP = Map.of("MobileOS", "ETC", "MobileApp", "Odorok", "numOfRows", "8000","pageNo", "1", "_type", "json", "serviceKey", secretKey);
     }
 
+    @Transactional
     @Override
     public void loadGilDatas() {
-        String json = WebClientUtil.doGetBlock(client, DURUNUBI_URL_GIL_LIST, DURUNUBI_PARAM_MAP);
+        String json = WebClientUtil.doGetBlock(client, DURUNUBI_URL_GIL_PATH, DURUNUBI_PARAM_MAP);
+        log.debug("gil data json : {}", json);
         JsonObject root = JsonParser.parseString(json).getAsJsonObject();
-        JsonArray items = root.getAsJsonArray(CONTENTS_TAG_NAME);
+        JsonArray items = root.getAsJsonObject("response").getAsJsonObject("body").getAsJsonObject("items").getAsJsonArray("item");
 
-        List<Gil> totGils = new ArrayList<>(INITIAL_LIST_SIZE);
+        List<Route> totRoutes = new ArrayList<>(INITIAL_LIST_SIZE);
         for(JsonElement ele : items) {
             JsonObject item = ele.getAsJsonObject();
 
-            Gil gil = new Gil();
-            gil.setWithJson(item);
-
-            totGils.add(gil);
+            Route route = new Route();
+            route.setWithJson(item);
+            log.debug("Parsed Route info : {}",route.toString());
+            totRoutes.add(route);
         }
-        gilRepository.saveAll(totGils); // saveAll의 결과로 모든 엔티티에 자동할당 값이 채워진다.
+        gilRepository.saveAll(totRoutes); // saveAll의 결과로 모든 엔티티에 자동할당 값이 채워진다.
     }
 
+    @Transactional
     @Override
     public void loadCourseDatas() {
-        String json = WebClientUtil.doGetBlock(client, DURUNUBI_URL_COURSE_LIST, DURUNUBI_PARAM_MAP);
+        String json = WebClientUtil.doGetBlock(client, DURUNUBI_URL_COURSE_PATH, DURUNUBI_PARAM_MAP);
 
+        log.debug("course data json : {}", json.substring(0, 1000));
         JsonObject root = JsonParser.parseString(json).getAsJsonObject();
-        JsonArray items = root.getAsJsonArray(CONTENTS_TAG_NAME);
+        JsonArray items = root.getAsJsonObject("response").getAsJsonObject("body").getAsJsonObject("items").getAsJsonArray("item");
 
         for(JsonElement ele : items) {
             JsonObject item = ele.getAsJsonObject();
@@ -102,9 +114,11 @@ public class DurunubiDataServiceImpl implements DurunubiDataService{
         }
     }
 
+    @Transactional
     @Override
     public void loadGPX(String url, Long crsId) {
         String gpxXml = client.get().uri(url).accept(MediaType.APPLICATION_XML).retrieve().bodyToMono(String.class).block();
+        log.debug("path data xml : {}", gpxXml.substring(0, 1000));
         SAXParserFactory factory = SAXParserFactory.newInstance();
         SAXParser parser;
         try {
@@ -112,7 +126,7 @@ public class DurunubiDataServiceImpl implements DurunubiDataService{
             DurunubiXmlHandler handler = new DurunubiXmlHandler();
             handler.init(crsId);
 
-            parser.parse(gpxXml, handler);
+            parser.parse(new InputSource(new StringReader(gpxXml)), handler);
 
             List<PathCoord> track = handler.getCoords();
             pathCoordRepository.saveAll(track);
@@ -132,6 +146,7 @@ public class DurunubiDataServiceImpl implements DurunubiDataService{
     public void loadToLocalDB() {
         loadGilDatas();
         loadCourseDatas();
+        log.debug("로컬 DB로 업데이트 완료!");
     }
 
     @Override
@@ -144,6 +159,7 @@ public class DurunubiDataServiceImpl implements DurunubiDataService{
         private final String TRACK_POINT_TAG_NAME = "trkpt";
         private final String LATITUDE_ATTR_NAME = "lat";
         private final String LONGITUDE_ATTR_NAME = "lon";
+        private int ordering = 0;
 
         private List<PathCoord> coords;
         private Long crsId;
@@ -151,17 +167,25 @@ public class DurunubiDataServiceImpl implements DurunubiDataService{
         public void init(long id) {
             coords = new ArrayList<>();
             this.crsId = id;
+            ordering = 0;
         }
 
         @Override
         public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-            if(qName.equalsIgnoreCase(TRACK_POINT_TAG_NAME)) {
+            if (qName.equalsIgnoreCase(TRACK_POINT_TAG_NAME)) {
                 PathCoord coord = new PathCoord();
                 coord.setLatitude(Double.parseDouble(attributes.getValue(LATITUDE_ATTR_NAME)));
                 coord.setLongitude(Double.parseDouble(attributes.getValue(LONGITUDE_ATTR_NAME)));
                 coord.setCourseId(crsId);
+                coord.setOrdering(ordering++);
                 coords.add(coord);
             }
         }
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void loadDataFromApiServerOnce() {
+        log.debug("attempt to load datas from durunubi api -------------");
+        loadToLocalDB();
     }
 }


### PR DESCRIPTION
🔨 작업 내용
게시글, 명소, 인벤토리, 업적, 프로필, 질병 목록, 게시글 이미지, 컨텐츠 종류, 테마, 구매이력, 티어, 프로필 데코, 시도, 시군구, 아이템
도메인 엔티티 클래스 작성

📎 관련 이슈
Jira: KAN-28